### PR TITLE
Update requirements.txt such that scripts work out of the box

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ requests==2.27.1
 torch==1.12.1
 torchvision==0.13.1
 numpy==1.21.2
-transformers==4.19.2 
+transformers==4.25.1 
 diffusers==0.3.0
 scipy==1.9.1
 ftfy==6.1.1


### PR DESCRIPTION
The class `CLIPTextModelWithProjection` is only available starting in `transformers>=4.25.1`.